### PR TITLE
feat(extend): tiny masked diffusion language model (MDLM-style)

### DIFF
--- a/src/diffusion/generate.py
+++ b/src/diffusion/generate.py
@@ -1,0 +1,111 @@
+"""Reverse diffusion: iteratively denoise a fully-masked sequence.
+
+Decoding strategy: at each step t, the model predicts the clean token for
+every position. We greedily commit tokens that are unmasked (argmax), and
+keep the rest masked for the next step — similar to the "absorbing" schedule
+in MDLM / Austin et al. 2021.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from src.diffusion.model import DiffusionTransformer
+from src.diffusion.vocab import MASK_ID, decode
+
+
+def generate(
+    model: DiffusionTransformer,
+    seq_len: int = 64,
+    steps: int = 20,
+    device: torch.device | None = None,
+    T: int = 100,
+) -> tuple[str, list[str]]:
+    """Generate a sequence via iterative masked diffusion.
+
+    Starts from a fully-masked sequence and unmasks tokens over `steps` rounds.
+    At each round t (from T down to 1), the model predicts clean tokens;
+    positions with high confidence are committed (unmasked), the rest remain
+    masked for the next round.
+
+    Args:
+        model: Trained DiffusionTransformer.
+        seq_len: Length of the sequence to generate.
+        steps: Number of denoising steps (≤ T).
+        device: Target device.
+        T: Total diffusion steps the model was trained with.
+
+    Returns:
+        final_text: Decoded final string.
+        trajectory: List of decoded strings at each step (for visualisation).
+    """
+    if device is None:
+        device = next(model.parameters()).device
+
+    model.eval()
+    x = torch.full((1, seq_len), MASK_ID, dtype=torch.long, device=device)
+    trajectory: list[str] = []
+
+    timesteps = torch.linspace(T, 1, steps, dtype=torch.long, device=device)
+
+    with torch.no_grad():
+        for step_idx, t_val in enumerate(timesteps):
+            t = t_val.unsqueeze(0)   # (1,)
+            logits = model(x, t)     # (1, L, V)
+            probs = logits.softmax(dim=-1)
+
+            # Greedy pick for masked positions
+            predicted = logits.argmax(dim=-1)   # (1, L)
+
+            # Fraction of tokens to reveal at this step (schedule: reveal
+            # proportionally more as t decreases)
+            frac_revealed = 1.0 - (t_val.item() / T)
+            n_reveal = max(1, int(frac_revealed * seq_len))
+
+            # Among still-masked positions, pick the n_reveal most confident
+            still_masked = (x == MASK_ID).squeeze(0)  # (L,)
+            if still_masked.any():
+                confidence = probs[0].max(dim=-1).values  # (L,)
+                confidence[~still_masked] = -1.0          # ignore unmasked
+                top_k = confidence.topk(min(n_reveal, still_masked.sum().item())).indices
+                x[0, top_k] = predicted[0, top_k]
+
+            trajectory.append(decode(x[0].tolist()))
+
+    return decode(x[0].tolist()), trajectory
+
+
+def generate_autoregressive(
+    model: DiffusionTransformer,
+    seq_len: int = 64,
+    device: torch.device | None = None,
+    T: int = 100,
+) -> str:
+    """Baseline: token-by-token left-to-right generation.
+
+    Uses the diffusion model at t=1 (minimal noise) as a proxy AR model:
+    fills positions left-to-right using the model's argmax prediction,
+    conditioning on already-filled tokens.
+
+    Args:
+        model: Trained DiffusionTransformer.
+        seq_len: Sequence length to generate.
+        device: Target device.
+        T: Diffusion steps the model was trained with.
+
+    Returns:
+        Generated string.
+    """
+    if device is None:
+        device = next(model.parameters()).device
+
+    model.eval()
+    x = torch.full((1, seq_len), MASK_ID, dtype=torch.long, device=device)
+    t = torch.tensor([1], device=device)
+
+    with torch.no_grad():
+        for pos in range(seq_len):
+            logits = model(x, t)
+            x[0, pos] = logits[0, pos].argmax()
+
+    return decode(x[0].tolist())

--- a/src/diffusion/model.py
+++ b/src/diffusion/model.py
@@ -1,0 +1,117 @@
+"""Tiny Transformer denoiser for masked diffusion.
+
+Given a partially-masked sequence x_t and diffusion step t, predict the
+original token at every position (including non-masked ones — the model
+learns to reconstruct the full sequence at every step).
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn as nn
+
+from src.diffusion.vocab import VOCAB_SIZE
+
+
+class SinusoidalTimeEmbedding(nn.Module):
+    """Sinusoidal embedding for the discrete diffusion timestep."""
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """Embed timestep t.
+
+        Args:
+            t: Integer timesteps (B,).
+
+        Returns:
+            Embeddings (B, dim).
+        """
+        half = self.dim // 2
+        freqs = torch.exp(
+            -math.log(10000) * torch.arange(half, device=t.device) / (half - 1)
+        )
+        args = t.float().unsqueeze(1) * freqs.unsqueeze(0)   # (B, half)
+        return torch.cat([args.sin(), args.cos()], dim=-1)    # (B, dim)
+
+
+class DiffusionTransformer(nn.Module):
+    """Small Transformer denoiser.
+
+    Architecture:
+        - Token embedding (vocab_size → d_model)
+        - Sinusoidal time embedding projected to d_model, added to each position
+        - N Transformer encoder layers (bidirectional — no causal mask)
+        - Linear head: d_model → vocab_size (logits over clean tokens)
+
+    Args:
+        vocab_size: Vocabulary size (default from vocab.py).
+        d_model: Token embedding / hidden dimension.
+        n_heads: Number of attention heads.
+        n_layers: Number of Transformer encoder layers.
+        max_len: Maximum sequence length.
+        dropout: Dropout probability.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int = VOCAB_SIZE,
+        d_model: int = 128,
+        n_heads: int = 4,
+        n_layers: int = 3,
+        max_len: int = 64,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        self.token_emb = nn.Embedding(vocab_size, d_model)
+        self.pos_emb = nn.Embedding(max_len, d_model)
+        self.time_emb = SinusoidalTimeEmbedding(d_model)
+        self.time_proj = nn.Linear(d_model, d_model)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=n_heads,
+            dim_feedforward=d_model * 4,
+            dropout=dropout,
+            batch_first=True,
+            norm_first=True,    # pre-norm for stability
+        )
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=n_layers)
+        self.head = nn.Linear(d_model, vocab_size)
+
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        nn.init.normal_(self.token_emb.weight, std=0.02)
+        nn.init.normal_(self.pos_emb.weight, std=0.02)
+        nn.init.zeros_(self.head.bias)
+
+    def forward(self, x_t: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        """Predict clean token logits from noisy sequence.
+
+        Args:
+            x_t: Noisy token IDs (B, L) int64.
+            t: Diffusion timestep (B,) int64.
+
+        Returns:
+            Logits (B, L, vocab_size).
+        """
+        B, L = x_t.shape
+        positions = torch.arange(L, device=x_t.device).unsqueeze(0)  # (1, L)
+
+        # Token + positional embeddings
+        h = self.token_emb(x_t) + self.pos_emb(positions)
+
+        # Time conditioning: broadcast over sequence positions
+        t_emb = self.time_proj(self.time_emb(t))   # (B, d_model)
+        h = h + t_emb.unsqueeze(1)                 # (B, L, d_model)
+
+        h = self.transformer(h)
+        return self.head(h)
+
+    def num_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)

--- a/src/diffusion/noise.py
+++ b/src/diffusion/noise.py
@@ -1,0 +1,56 @@
+"""Masked diffusion noise schedule.
+
+Forward process: independently mask each token with probability alpha(t),
+where t is uniformly sampled from {1, ..., T} and alpha increases with t.
+
+This follows the MDLM (Masked Diffusion Language Model) formulation:
+  - t=0: original sequence (no masking)
+  - t=T: fully masked sequence
+  - alpha(t) = t / T  (linear schedule)
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def mask_rate(t: torch.Tensor, T: int) -> torch.Tensor:
+    """Compute per-sample masking probability alpha(t) = t/T.
+
+    Args:
+        t: Integer diffusion timestep tensor (...,).
+        T: Total number of diffusion steps.
+
+    Returns:
+        Float tensor of same shape as t, values in (0, 1].
+    """
+    return t.float() / T
+
+
+def forward_diffuse(
+    x: torch.Tensor,
+    t: torch.Tensor,
+    T: int,
+    mask_id: int,
+) -> torch.Tensor:
+    """Apply forward diffusion: mask tokens with probability alpha(t).
+
+    Args:
+        x: Token IDs (B, L) int64.
+        t: Diffusion timestep per sample (B,) int64.
+        T: Total diffusion steps.
+        mask_id: Token ID for the MASK token.
+
+    Returns:
+        Noisy token IDs (B, L) int64, with some tokens replaced by mask_id.
+    """
+    alpha = mask_rate(t, T)           # (B,)
+    # Sample a Bernoulli mask: 1 = replace with MASK
+    noise = torch.rand_like(x, dtype=torch.float)
+    should_mask = noise < alpha.unsqueeze(1)   # (B, L)
+    return torch.where(should_mask, torch.full_like(x, mask_id), x)
+
+
+def sample_timesteps(batch_size: int, T: int, device: torch.device) -> torch.Tensor:
+    """Sample uniformly from {1, ..., T}."""
+    return torch.randint(1, T + 1, (batch_size,), device=device)

--- a/src/diffusion/train.py
+++ b/src/diffusion/train.py
@@ -1,0 +1,128 @@
+"""Training loop for the masked diffusion language model."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, Dataset
+
+from src.diffusion.model import DiffusionTransformer
+from src.diffusion.noise import forward_diffuse, sample_timesteps
+from src.diffusion.vocab import MASK_ID, PAD_ID, encode
+
+logger = logging.getLogger(__name__)
+
+# ── Toy dataset ───────────────────────────────────────────────────────────────
+
+# Short sentences that stress long-range structure (verb-object agreement,
+# rhyme, repeated patterns). The model needs to denoise the full sequence
+# holistically — impossible for a purely left-to-right AR model without
+# attending right-of-cursor.
+_SENTENCES = [
+    "the cat sat on the mat",
+    "the dog lay on the log",
+    "a fox in a box by the docks",
+    "the quick brown fox jumps over the lazy dog",
+    "to be or not to be that is the question",
+    "all that glitters is not gold",
+    "the sun also rises in the east",
+    "every good boy deserves fudge",
+    "she sells seashells by the seashore",
+    "how much wood would a woodchuck chuck",
+    "peter piper picked a peck of pickled peppers",
+    "the rain in spain stays mainly in the plain",
+    "red lorry yellow lorry red lorry yellow lorry",
+    "unique new york unique new york you know you need unique new york",
+    "if a black bug bleeds black blood what color blood bleeds a blue bug",
+]
+
+
+class CharDataset(Dataset):
+    """Toy character-level dataset. Sequences are padded to seq_len."""
+
+    def __init__(self, sentences: list[str], seq_len: int = 64):
+        self.seq_len = seq_len
+        self.data: list[torch.Tensor] = []
+        for s in sentences:
+            ids = encode(s)[:seq_len]
+            # Pad to seq_len
+            ids += [PAD_ID] * (seq_len - len(ids))
+            self.data.append(torch.tensor(ids, dtype=torch.long))
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        return self.data[idx]
+
+
+# ── Trainer ───────────────────────────────────────────────────────────────────
+
+@dataclass
+class DiffusionTrainConfig:
+    T: int = 100               # diffusion steps
+    epochs: int = 200
+    batch_size: int = 8
+    lr: float = 3e-4
+    seq_len: int = 64          # must match model's max_len
+    device: str = "cpu"
+
+
+def train_diffusion(
+    model: DiffusionTransformer,
+    cfg: DiffusionTrainConfig,
+    sentences: list[str] | None = None,
+) -> list[float]:
+    """Train the DiffusionTransformer on the toy sentence dataset.
+
+    Loss: cross-entropy over ALL positions (not just masked ones).
+    Following MDLM, the model learns to reconstruct the full clean sequence
+    from the noisy input at every timestep.
+
+    Args:
+        model: DiffusionTransformer to train.
+        cfg: Training configuration.
+        sentences: Optional list of training sentences (defaults to built-in set).
+
+    Returns:
+        List of per-epoch mean losses.
+    """
+    if sentences is None:
+        sentences = _SENTENCES
+
+    device = torch.device(cfg.device)
+    model.to(device).train()
+
+    ds = CharDataset(sentences, seq_len=cfg.seq_len)
+    loader = DataLoader(ds, batch_size=cfg.batch_size, shuffle=True)
+    opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr)
+
+    history = []
+    for epoch in range(1, cfg.epochs + 1):
+        epoch_loss = 0.0
+        for x0 in loader:
+            x0 = x0.to(device)
+            t = sample_timesteps(x0.shape[0], cfg.T, device)
+            x_t = forward_diffuse(x0, t, cfg.T, MASK_ID)
+
+            logits = model(x_t, t)   # (B, L, V)
+            loss = nn.functional.cross_entropy(
+                logits.view(-1, logits.shape[-1]),
+                x0.view(-1),
+                ignore_index=PAD_ID,
+            )
+            opt.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            opt.step()
+            epoch_loss += loss.item()
+
+        mean_loss = epoch_loss / len(loader)
+        history.append(mean_loss)
+        if epoch % 50 == 0 or epoch == 1:
+            logger.info("Epoch %3d/%d  loss=%.4f", epoch, cfg.epochs, mean_loss)
+
+    return history

--- a/src/diffusion/vocab.py
+++ b/src/diffusion/vocab.py
@@ -1,0 +1,36 @@
+"""Character-level vocabulary with a dedicated MASK token."""
+
+from __future__ import annotations
+
+_PRINTABLE = (
+    " !\"#$%&'()*+,-./0123456789:;<=>?@"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
+    "abcdefghijklmnopqrstuvwxyz{|}~"
+)
+
+MASK_TOKEN = "<MASK>"
+PAD_TOKEN = "<PAD>"
+
+_SPECIAL = [PAD_TOKEN, MASK_TOKEN]
+CHARS = _SPECIAL + list(_PRINTABLE)
+
+VOCAB_SIZE = len(CHARS)
+MASK_ID = CHARS.index(MASK_TOKEN)
+PAD_ID = CHARS.index(PAD_TOKEN)
+
+_char2id: dict[str, int] = {c: i for i, c in enumerate(CHARS)}
+_id2char: dict[int, str] = {i: c for i, c in enumerate(CHARS)}
+
+
+def encode(text: str) -> list[int]:
+    """Encode a string to a list of token IDs (unknown chars → PAD_ID)."""
+    return [_char2id.get(ch, PAD_ID) for ch in text]
+
+
+def decode(ids: list[int]) -> str:
+    """Decode token IDs to a string (skipping PAD and MASK)."""
+    return "".join(
+        _id2char.get(i, "?")
+        for i in ids
+        if i not in (PAD_ID, MASK_ID)
+    )

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -1,0 +1,133 @@
+"""Tests for the masked diffusion language model."""
+
+import torch
+import pytest
+
+from src.diffusion.generate import generate, generate_autoregressive
+from src.diffusion.model import DiffusionTransformer
+from src.diffusion.noise import forward_diffuse, mask_rate, sample_timesteps
+from src.diffusion.train import CharDataset, DiffusionTrainConfig, train_diffusion
+from src.diffusion.vocab import MASK_ID, VOCAB_SIZE, decode, encode
+
+SEQ_LEN = 16
+T = 20
+
+
+def _small_model() -> DiffusionTransformer:
+    return DiffusionTransformer(
+        vocab_size=VOCAB_SIZE, d_model=32, n_heads=2, n_layers=1, max_len=SEQ_LEN
+    )
+
+
+# ── Vocab ─────────────────────────────────────────────────────────────────────
+
+def test_encode_decode_roundtrip():
+    text = "hello world"
+    assert decode(encode(text)) == text
+
+
+def test_mask_id_not_in_decode():
+    ids = [MASK_ID, MASK_ID, *encode("hi")]
+    assert "<MASK>" not in decode(ids)
+
+
+def test_vocab_size_positive():
+    assert VOCAB_SIZE > 2
+
+
+# ── Noise ─────────────────────────────────────────────────────────────────────
+
+def test_mask_rate_bounds():
+    t = torch.tensor([0, 5, 10, 20])
+    r = mask_rate(t, T=20)
+    assert (r >= 0).all() and (r <= 1).all()
+
+
+def test_forward_diffuse_shape():
+    x = torch.randint(2, VOCAB_SIZE, (4, SEQ_LEN))
+    t = sample_timesteps(4, T, torch.device("cpu"))
+    x_t = forward_diffuse(x, t, T, MASK_ID)
+    assert x_t.shape == x.shape
+
+
+def test_forward_diffuse_t0_no_mask():
+    """At t=0 nothing should be masked."""
+    x = torch.randint(2, VOCAB_SIZE, (8, SEQ_LEN))
+    t = torch.zeros(8, dtype=torch.long)
+    x_t = forward_diffuse(x, t, T, MASK_ID)
+    assert (x_t == x).all()
+
+
+def test_forward_diffuse_tT_all_masked():
+    """At t=T everything should be masked (with high probability)."""
+    torch.manual_seed(42)
+    x = torch.randint(2, VOCAB_SIZE, (64, SEQ_LEN))
+    t = torch.full((64,), T, dtype=torch.long)
+    x_t = forward_diffuse(x, t, T, MASK_ID)
+    mask_frac = (x_t == MASK_ID).float().mean().item()
+    assert mask_frac > 0.95
+
+
+# ── Model ─────────────────────────────────────────────────────────────────────
+
+def test_model_output_shape():
+    model = _small_model()
+    x = torch.randint(0, VOCAB_SIZE, (4, SEQ_LEN))
+    t = torch.randint(1, T + 1, (4,))
+    logits = model(x, t)
+    assert logits.shape == (4, SEQ_LEN, VOCAB_SIZE)
+
+
+def test_model_param_count():
+    model = _small_model()
+    assert 0 < model.num_parameters() < 1_000_000
+
+
+def test_model_gradients_flow():
+    model = _small_model()
+    x = torch.randint(0, VOCAB_SIZE, (2, SEQ_LEN))
+    t = torch.randint(1, T + 1, (2,))
+    loss = model(x, t).mean()
+    loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, f"No gradient for {name}"
+
+
+# ── Training ──────────────────────────────────────────────────────────────────
+
+def test_train_loss_decreases():
+    model = _small_model()
+    cfg = DiffusionTrainConfig(T=T, epochs=30, batch_size=8, lr=3e-4, seq_len=SEQ_LEN, device="cpu")
+    history = train_diffusion(model, cfg, sentences=["the cat sat on the mat"] * 8)
+    assert history[-1] < history[0], f"Loss did not decrease: {history[0]:.4f} → {history[-1]:.4f}"
+
+
+def test_char_dataset_len_and_shape():
+    ds = CharDataset(["hello world", "foo bar"], seq_len=SEQ_LEN)
+    assert len(ds) == 2
+    item = ds[0]
+    assert item.shape == (SEQ_LEN,)
+    assert item.dtype == torch.long
+
+
+# ── Generation ────────────────────────────────────────────────────────────────
+
+def test_generate_returns_string():
+    model = _small_model()
+    text, trajectory = generate(model, seq_len=SEQ_LEN, steps=5, T=T)
+    assert isinstance(text, str)
+    assert len(trajectory) == 5
+
+
+def test_generate_trajectory_progresses():
+    """Each step should unmask more tokens (trajectory grows or stays same length)."""
+    model = _small_model()
+    _, trajectory = generate(model, seq_len=SEQ_LEN, steps=8, T=T)
+    # The last step should have revealed at least as many chars as the first
+    assert len(trajectory[-1]) >= len(trajectory[0])
+
+
+def test_generate_autoregressive_returns_string():
+    model = _small_model()
+    text = generate_autoregressive(model, seq_len=SEQ_LEN, T=T)
+    assert isinstance(text, str)


### PR DESCRIPTION
## Summary

Implements a character-level masked diffusion language model following the MDLM (Masked Diffusion LM) formulation.

- **`vocab.py`** — 96-char vocabulary with `<PAD>` and `<MASK>` special tokens
- **`noise.py`** — linear masking schedule `alpha(t) = t/T`; `forward_diffuse` independently masks each token with Bernoulli probability `alpha(t)`
- **`model.py`** — `DiffusionTransformer`: bidirectional Transformer (no causal mask) with sinusoidal time embedding broadcast across all positions; pre-norm for stability
- **`train.py`** — `CharDataset` (toy sentences) + `train_diffusion` (CE loss over all positions, not just masked)
- **`generate.py`** — two generation modes:
  - `generate()`: confidence-based iterative unmasking — reveal the most confident positions at each step, running for `steps` rounds from fully masked → clean
  - `generate_autoregressive()`: left-to-right baseline using the same model at `t=1`

## Key architectural contrast

| | Autoregressive | Masked Diffusion |
|---|---|---|
| Attention | Causal (left-only) | Bidirectional (full context) |
| Generation | Token-by-token, 1 pass | All positions, N passes |
| Long-range dependencies | Limited by direction | Holistic from step 1 |
| Inference speed | O(L) sequential steps | O(steps) parallel steps |

## Test results

```
15 passed in 1.47s
```

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)